### PR TITLE
simple hs integration (demonstrator)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: stack
-version: '2.8.0'
+version: '2.8.0.1'
 synopsis: The Haskell Tool Stack
 description: |
   Please see the documentation at <https://docs.haskellstack.org>

--- a/stack.cabal
+++ b/stack.cabal
@@ -1,13 +1,13 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
 -- hash: 4d6bc382d1f25fc7283e144b701061b38a5f10879c44997cfdc0b9f3147ce352
 
 name:           stack
-version:        2.8.0
+version:        2.8.0.1
 synopsis:       The Haskell Tool Stack
 description:    Please see the documentation at <https://docs.haskellstack.org>
                 for usage information.


### PR DESCRIPTION
This is a straightforward patch of Stack.Setup to call out to `hs`
to discover GHC toolchain installations that may reside in `stack`
or `ghcup`.

Done properly, this behaviour will be controlled by a global
configuration of course -- this is just a preview/demonstrator.

The version has been bump to 2.8.0.1.

Note: Documentation fixes for https://docs.haskellstack.org/en/stable/ should target the "stable" branch, not master.

Please include the following checklist in your PR:

* [ ] Any changes that could be relevant to users have been recorded in the ChangeLog.md
* [ ] The documentation has been updated, if necessary.

Please also shortly describe how you tested your change. Bonus points for added tests!
